### PR TITLE
Resolve 'invalid application of ‘sizeof’ to incomplete type ‘boost::STATIC_ASSERTION_FAILURE<false>' error with boost 1.5x

### DIFF
--- a/src/rpcrawtransaction.cpp
+++ b/src/rpcrawtransaction.cpp
@@ -238,7 +238,7 @@ Value listunspent(const Array& params, bool fHelp)
             CTxDestination address;
             if (ExtractDestination(pk, address))
             {
-                const CScriptID& hash = boost::get<const CScriptID&>(address);
+                const CScriptID& hash = boost::get<CScriptID>(address);
                 CScript redeemScript;
                 if (pwalletMain->GetCScript(hash, redeemScript))
                     entry.push_back(Pair("redeemScript", HexStr(redeemScript.begin(), redeemScript.end())));


### PR DESCRIPTION
https://github.com/bitcoin/bitcoin/issues/6113#issuecomment-298234393

Compilation fails on Ubuntu 16.04 using Boost 1.54 and 1.58. Fixing this single line allows for compilation to succeed. The resulting devcoind runs correctly on 64-bit linux without any other changes.